### PR TITLE
an attempt to separate domain objects from events

### DIFF
--- a/src/main/java/se/omegapoint/conferre/conference/domain/Conference.java
+++ b/src/main/java/se/omegapoint/conferre/conference/domain/Conference.java
@@ -2,28 +2,32 @@ package se.omegapoint.conferre.conference.domain;
 
 import se.omegapoint.conferre.Entity;
 import se.omegapoint.conferre.Identity;
-import se.omegapoint.conferre.event.Event;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
 
 public class Conference extends Entity {
 
-    private final String name;
+	private final String name;
 
-    public Conference(String name) {
-        super(Identity.instance());
-        this.name = name;
-    }
+	public Conference(String name) {
+		this(Identity.instance(), name);
+	}
 
-    public String getName() {
-        return name;
-    }
+	private Conference(Identity conferenceId, String name) {
+		super(conferenceId);
+		this.name = name;
+	}
 
-    public Event asCreatedEvent() {
-        return new Event("CREATED", this);
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void requireGood(Conference existing) {
-        if (name.equals(existing.name)) {
-            throw new IllegalStateException("Conflicting conference: " + name);
-        }
-    }
+	void requireGood(Conference existing) {
+		if (name.equals(existing.name)) {
+			throw new IllegalStateException("Conflicting conference: " + name);
+		}
+	}
+
+	static Conference fromEvent(ConferenceCreated conferenceCreated) {
+		return new Conference(conferenceCreated.getConferenceId(), conferenceCreated.getName());
+	}
 }

--- a/src/main/java/se/omegapoint/conferre/conference/domain/ConferenceStore.java
+++ b/src/main/java/se/omegapoint/conferre/conference/domain/ConferenceStore.java
@@ -2,6 +2,7 @@ package se.omegapoint.conferre.conference.domain;
 
 import org.springframework.stereotype.Component;
 import se.omegapoint.conferre.Identity;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
 import se.omegapoint.conferre.event.Event;
 
 import java.util.ArrayList;
@@ -29,7 +30,7 @@ public class ConferenceStore {
 	}
 
 	private Conference created(Event event) {
-		Conference conference = (Conference) event.getPayload();
+		Conference conference = Conference.fromEvent((ConferenceCreated) event.getPayload());
 		store.put(conference.getId(), conference);
 		return conference;
 	}

--- a/src/main/java/se/omegapoint/conferre/conference/event/ConferenceCreated.java
+++ b/src/main/java/se/omegapoint/conferre/conference/event/ConferenceCreated.java
@@ -1,0 +1,29 @@
+package se.omegapoint.conferre.conference.event;
+
+import se.omegapoint.conferre.Identity;
+import se.omegapoint.conferre.conference.domain.Conference;
+import se.omegapoint.conferre.event.Event;
+
+public class ConferenceCreated {
+
+	private final Identity conferenceId;
+	private final String name;
+
+	private ConferenceCreated(Conference conference) {
+		this.name = conference.getName();
+		this.conferenceId = conference.getId();
+	}
+
+	public Identity getConferenceId() {
+		return conferenceId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public static Event asEvent(Conference conference) {
+		return new Event("CREATED", new ConferenceCreated(conference));
+	}
+
+}

--- a/src/main/java/se/omegapoint/conferre/conference/event/ConferenceCreated.java
+++ b/src/main/java/se/omegapoint/conferre/conference/event/ConferenceCreated.java
@@ -22,8 +22,12 @@ public class ConferenceCreated {
 		return name;
 	}
 
-	public static Event asEvent(Conference conference) {
-		return new Event("CREATED", new ConferenceCreated(conference));
+	public static ConferenceCreated from(Conference conference) {
+		return new ConferenceCreated(conference);
+	}
+
+	public Event asEvent() {
+		return new Event("CREATED", this);
 	}
 
 }

--- a/src/main/java/se/omegapoint/conferre/conference/rest/ConferenceController.java
+++ b/src/main/java/se/omegapoint/conferre/conference/rest/ConferenceController.java
@@ -22,8 +22,7 @@ public class ConferenceController {
 
     @RequestMapping(method = RequestMethod.POST)
     public Conference createConference(Conference conference) {
-        conferenceService.createConference(conference);
-        return conference;
+        return conferenceService.createConference(conference);
     }
 
     @RequestMapping(method = RequestMethod.GET)

--- a/src/main/java/se/omegapoint/conferre/conference/service/ConferenceService.java
+++ b/src/main/java/se/omegapoint/conferre/conference/service/ConferenceService.java
@@ -28,7 +28,7 @@ public class ConferenceService {
 
 	public synchronized Conference createConference(Conference conference) {
 		rules.validate(store, conference);
-		return publish(ConferenceCreated.asEvent(conference));
+		return publish(ConferenceCreated.from(conference).asEvent());
 	}
 
 	private Conference publish(Event event) {

--- a/src/main/java/se/omegapoint/conferre/conference/service/ConferenceService.java
+++ b/src/main/java/se/omegapoint/conferre/conference/service/ConferenceService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import se.omegapoint.conferre.conference.domain.Conference;
 import se.omegapoint.conferre.conference.domain.ConferenceRules;
 import se.omegapoint.conferre.conference.domain.ConferenceStore;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
 import se.omegapoint.conferre.event.Event;
 import se.omegapoint.conferre.event.EventBus;
 
@@ -27,8 +28,7 @@ public class ConferenceService {
 
 	public synchronized Conference createConference(Conference conference) {
 		rules.validate(store, conference);
-		Event event = new Event("CREATED", conference);
-		return publish(event);
+		return publish(ConferenceCreated.asEvent(conference));
 	}
 
 	private Conference publish(Event event) {

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/ProposalRules.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/ProposalRules.java
@@ -3,6 +3,7 @@ package se.omegapoint.conferre.proposal.domain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import se.omegapoint.conferre.Identity;
+import se.omegapoint.conferre.proposal.domain.supportive.ConferenceProposalRepository;
 
 @Component
 public class ProposalRules {

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/Conference.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/Conference.java
@@ -1,11 +1,11 @@
 package se.omegapoint.conferre.proposal.domain.supportive;
 
 import se.omegapoint.conferre.Entity;
-import se.omegapoint.conferre.conference.event.ConferenceCreated;
+import se.omegapoint.conferre.Identity;
 
 public class Conference extends Entity {
 
-	public Conference(ConferenceCreated conferenceCreated) {
-		super(conferenceCreated.getConferenceId());
+	public Conference(Identity conferenceId) {
+		super(conferenceId);
 	}
 }

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/Conference.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/Conference.java
@@ -1,0 +1,11 @@
+package se.omegapoint.conferre.proposal.domain.supportive;
+
+import se.omegapoint.conferre.Entity;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
+
+public class Conference extends Entity {
+
+	public Conference(ConferenceCreated conferenceCreated) {
+		super(conferenceCreated.getConferenceId());
+	}
+}

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceBuilder.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceBuilder.java
@@ -1,0 +1,21 @@
+package se.omegapoint.conferre.proposal.domain.supportive;
+
+import se.omegapoint.conferre.Identity;
+
+class ConferenceBuilder {
+
+	private final Identity conferenceId;
+
+	private ConferenceBuilder(Identity conferenceId) {
+		this.conferenceId = conferenceId;
+
+	}
+
+	static ConferenceBuilder aConference(Identity conferenceId) {
+		return new ConferenceBuilder(conferenceId);
+	}
+
+	Conference build() {
+		return new Conference(conferenceId);
+	}
+}

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceProposalRepository.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceProposalRepository.java
@@ -8,7 +8,6 @@ import se.omegapoint.conferre.event.Event;
 import se.omegapoint.conferre.event.EventBus;
 import se.omegapoint.conferre.event.EventListener;
 import se.omegapoint.conferre.event.TopicName;
-import se.omegapoint.conferre.proposal.domain.supportive.Conference;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -37,10 +36,10 @@ public class ConferenceProposalRepository implements EventListener {
 		applyEvent(event);
 	}
 
-    private void applyEvent(Event event) {
-	    Conference conference = new Conference((ConferenceCreated) event.getPayload());
-        currentState.add(conference.getId());
-    }
+	private void applyEvent(Event event) {
+		Conference conference = ConferenceBuilder.aConference(((ConferenceCreated) event.getPayload()).getConferenceId()).build();
+		currentState.add(conference.getId());
+	}
 
 	public boolean exists(Identity conferenceId) {
 		return currentState.contains(conferenceId);

--- a/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceProposalRepository.java
+++ b/src/main/java/se/omegapoint/conferre/proposal/domain/supportive/ConferenceProposalRepository.java
@@ -1,13 +1,14 @@
-package se.omegapoint.conferre.proposal.domain;
+package se.omegapoint.conferre.proposal.domain.supportive;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import se.omegapoint.conferre.Identity;
-import se.omegapoint.conferre.conference.domain.Conference;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
 import se.omegapoint.conferre.event.Event;
 import se.omegapoint.conferre.event.EventBus;
 import se.omegapoint.conferre.event.EventListener;
 import se.omegapoint.conferre.event.TopicName;
+import se.omegapoint.conferre.proposal.domain.supportive.Conference;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -37,7 +38,7 @@ public class ConferenceProposalRepository implements EventListener {
 	}
 
     private void applyEvent(Event event) {
-        Conference conference = (Conference) event.getPayload();
+	    Conference conference = new Conference((ConferenceCreated) event.getPayload());
         currentState.add(conference.getId());
     }
 

--- a/src/main/java/se/omegapoint/conferre/registration/domain/RegistrationRules.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/RegistrationRules.java
@@ -1,6 +1,7 @@
 package se.omegapoint.conferre.registration.domain;
 
 import org.springframework.stereotype.Component;
+import se.omegapoint.conferre.registration.domain.supportive.ConferenceRegistrationRepository;
 
 @Component
 public class RegistrationRules {

--- a/src/main/java/se/omegapoint/conferre/registration/domain/supportive/Conference.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/supportive/Conference.java
@@ -1,0 +1,11 @@
+package se.omegapoint.conferre.registration.domain.supportive;
+
+import se.omegapoint.conferre.Entity;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
+
+public class Conference extends Entity {
+
+	public Conference(ConferenceCreated conferenceCreated) {
+		super(conferenceCreated.getConferenceId());
+	}
+}

--- a/src/main/java/se/omegapoint/conferre/registration/domain/supportive/Conference.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/supportive/Conference.java
@@ -1,11 +1,11 @@
 package se.omegapoint.conferre.registration.domain.supportive;
 
 import se.omegapoint.conferre.Entity;
-import se.omegapoint.conferre.conference.event.ConferenceCreated;
+import se.omegapoint.conferre.Identity;
 
 public class Conference extends Entity {
 
-	public Conference(ConferenceCreated conferenceCreated) {
-		super(conferenceCreated.getConferenceId());
+	public Conference(Identity conferenceId) {
+		super(conferenceId);
 	}
 }

--- a/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceBuilder.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceBuilder.java
@@ -1,0 +1,21 @@
+package se.omegapoint.conferre.registration.domain.supportive;
+
+import se.omegapoint.conferre.Identity;
+
+class ConferenceBuilder {
+
+	private final Identity conferenceId;
+
+	private ConferenceBuilder(Identity conferenceId) {
+		this.conferenceId = conferenceId;
+
+	}
+
+	static ConferenceBuilder aConference(Identity conferenceId) {
+		return new ConferenceBuilder(conferenceId);
+	}
+
+	Conference build() {
+		return new Conference(conferenceId);
+	}
+}

--- a/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceRegistrationRepository.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceRegistrationRepository.java
@@ -1,9 +1,9 @@
-package se.omegapoint.conferre.registration.domain;
+package se.omegapoint.conferre.registration.domain.supportive;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import se.omegapoint.conferre.Identity;
-import se.omegapoint.conferre.conference.domain.Conference;
+import se.omegapoint.conferre.conference.event.ConferenceCreated;
 import se.omegapoint.conferre.event.Event;
 import se.omegapoint.conferre.event.EventBus;
 import se.omegapoint.conferre.event.EventListener;
@@ -36,7 +36,7 @@ public class ConferenceRegistrationRepository implements EventListener {
     }
 
     private void applyEvent(Event event) {
-        Conference conference = (Conference) event.getPayload();
+        Conference conference = new Conference((ConferenceCreated) event.getPayload());
         currentState.add(conference.getId());
     }
 

--- a/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceRegistrationRepository.java
+++ b/src/main/java/se/omegapoint/conferre/registration/domain/supportive/ConferenceRegistrationRepository.java
@@ -36,7 +36,7 @@ public class ConferenceRegistrationRepository implements EventListener {
     }
 
     private void applyEvent(Event event) {
-        Conference conference = new Conference((ConferenceCreated) event.getPayload());
+        Conference conference = ConferenceBuilder.aConference(((ConferenceCreated) event.getPayload()).getConferenceId()).build();
         currentState.add(conference.getId());
     }
 


### PR DESCRIPTION
I've made a first attempt to separate domain objects from events. The purpose is to break up the unsound dependencies the different modules have on each other. Starting with the Conference-object I've made a copy  of that object in each of the other modules (proposal and registration). I have also introduced a ConferenceCreated that is the event that are pushed on to the bus. I'm not sure where or how the events should be created, but I think it's okay if the event know about the domain but not vice versa.

